### PR TITLE
Improve planner UI and fix asset loading paths

### DIFF
--- a/app.js
+++ b/app.js
@@ -274,7 +274,7 @@ function robotSVG(unlocked){
 // -------------------- PWA Registration & Install ----------------------------
 function pwaSetup(){
   if('serviceWorker' in navigator){
-    navigator.serviceWorker.register('/sw.js').catch(()=>{});
+    navigator.serviceWorker.register('sw.js').catch(()=>{});
   }
   let deferredPrompt = null; const installBtn = $('#installBtn');
   window.addEventListener('beforeinstallprompt', (e)=>{
@@ -292,6 +292,15 @@ document.addEventListener('DOMContentLoaded', ()=>{
   document.querySelectorAll('nav [data-tab]').forEach(btn=>btn.addEventListener('click', ()=>switchTab(btn.dataset.tab)));
   $('#resetBtn').addEventListener('click',()=>{
     if(confirm('Reset all data? This cannot be undone.')){ state = { ...defaultState }; renderAll(); }
+  });
+  $('#updateBtn').addEventListener('click', async ()=>{
+    if('serviceWorker' in navigator && navigator.serviceWorker.controller){
+      const mc = new MessageChannel();
+      mc.port1.onmessage = () => window.location.reload();
+      navigator.serviceWorker.controller.postMessage({type:'CLEAR_CACHE'}, [mc.port2]);
+    } else {
+      window.location.reload();
+    }
   });
   renderAll();
   switchTab('planner');

--- a/index.html
+++ b/index.html
@@ -3,25 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#0f172a" />
+  <meta name="theme-color" content="#6366f1" />
   <title>3Do 🤖</title>
-  <link rel="manifest" href="/manifest.webmanifest" />
-  <link rel="stylesheet" href="/styles.css" />
+  <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <div class="wrap">
-    <header class="row" style="justify-content:space-between">
+    <header class="row topbar">
       <div>
         <h1>3Do 🤖</h1>
         <div class="muted">A focused planner with red/yellow/green slots, XP, and a weekly robot build.</div>
       </div>
       <div class="row">
         <button id="installBtn" class="btn install hidden">Install App</button>
-        <div class="card" style="padding:8px 12px">
+        <div class="card xp-card">
           <div class="muted" style="font-size:12px">XP (This Week)</div>
           <div id="xpWeek" style="font-size:18px;font-weight:600">0</div>
         </div>
-        <div class="card" style="padding:8px 12px">
+        <div class="card xp-card">
           <div class="muted" style="font-size:12px">XP (All‑Time)</div>
           <div id="xpAll" style="font-size:18px;font-weight:600">0</div>
         </div>
@@ -72,8 +72,11 @@
         </table>
       </div>
     </section>
+    <footer class="footer">
+      <button id="updateBtn" class="btn">Update</button>
+    </footer>
   </div>
 
-  <script src="/app.js"></script>
+  <script src="app.js"></script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -2,15 +2,15 @@
   "name": "3Do 🤖",
   "short_name": "3Do",
   "description": "A focused three‑slot planner with weekly robot XP build.",
-  "start_url": "/",
-  "scope": "/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#f8fafc",
-  "theme_color": "#0f172a",
+  "theme_color": "#6366f1",
   "icons": [
-    { "src": "/icons/icon.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icons/icon.png", "sizes": "512x512", "type": "image/png" },
-    { "src": "/icons/icon.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" },
-    { "src": "/icons/icon.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+    { "src": "icons/icon.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "icons/icon.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "icons/icon.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" },
+    { "src": "icons/icon.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
   ]
 }

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,21 @@
 
-:root{--bg:#f8fafc;--card:#ffffff;--ink:#0f172a;--muted:#475569;--border:#e2e8f0;--ring:#94a3b8}
-*{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial}
-.wrap{max-width:1000px;margin:0 auto;padding:24px}
-h1{font-size:28px;margin:0 0 8px} .muted{color:var(--muted)}
+:root{--bg:#e2e8f0;--bg2:#f8fafc;--card:#ffffff;--ink:#1e293b;--muted:#64748b;--border:#e2e8f0;--ring:#93c5fd;--accent:#6366f1}
+*{box-sizing:border-box}
+body{margin:0;min-height:100vh;background:linear-gradient(135deg,var(--bg2),var(--bg));color:var(--ink);font:15px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial}
+.wrap{max-width:1000px;margin:0 auto;padding:32px}
+h1{font-size:32px;margin:0 0 8px}
+.muted{color:var(--muted)}
 .row{display:flex;gap:12px;align-items:center}
-.tabs{display:flex;gap:8px;margin:16px 0}
-.btn{border:1px solid var(--border);background:#f1f5f9;padding:8px 12px;border-radius:12px;cursor:pointer}
+.topbar{justify-content:space-between;margin-bottom:24px}
+.tabs{display:flex;gap:8px;margin:16px 0;border-bottom:1px solid var(--border);padding-bottom:8px}
+.btn{border:1px solid var(--border);background:#f1f5f9;padding:8px 12px;border-radius:12px;cursor:pointer;transition:background .2s,transform .1s}
 .btn:hover{background:#fff}
-.btn.pri{background:#0f172a;color:#fff;border-color:#0f172a}
+.btn:active{transform:scale(.97)}
+.btn.pri{background:var(--accent);color:#fff;border-color:var(--accent)}
 .btn.warn{background:#fee2e2;border-color:#fecaca;color:#7f1d1d}
 .btn.good{background:#dcfce7;border-color:#bbf7d0;color:#14532d}
 .chip{font-size:12px;border:1px solid var(--border);background:#fff;border-radius:999px;padding:2px 8px}
-.card{background:var(--card);border:1px solid var(--border);border-radius:16px;box-shadow:0 1px 2px rgba(0,0,0,.04);padding:16px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:16px;box-shadow:0 2px 4px rgba(0,0,0,.06);padding:16px}
 .grid{display:grid;gap:12px}
 @media(min-width:840px){.grid.cols-3{grid-template-columns:repeat(3,1fr)} .grid.cols-2{grid-template-columns:2fr 1fr}}
 label{display:block;font-size:12px;color:var(--muted);margin:10px 0 4px}
@@ -25,3 +29,5 @@ th,td{padding:10px;text-align:left;border-top:1px solid var(--border)}
 .right{margin-left:auto}
 .hidden{display:none}
 .install{background:#eef2ff;border-color:#c7d2fe;color:#3730a3}
+.xp-card{padding:8px 12px;width:110px}
+.footer{text-align:center;margin-top:24px}

--- a/sw.js
+++ b/sw.js
@@ -1,11 +1,11 @@
 const CACHE_VERSION = 'v1.0.1';
 const CACHE_NAME = `three-slot-cache-${CACHE_VERSION}`;
 const CORE_ASSETS = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/app.js',
-  '/manifest.webmanifest',
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './manifest.webmanifest',
 ];
 
 self.addEventListener('install', (event) => {
@@ -25,6 +25,18 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(
     caches.match(req).then(cached => cached || fetch(req).then(res => {
       const clone = res.clone(); caches.open(CACHE_NAME).then(c => c.put(req, clone)); return res;
-    }).catch(()=> caches.match('/index.html')))
+    }).catch(()=> caches.match('index.html')))
   );
+});
+
+self.addEventListener('message', (event) => {
+  if(event.data && event.data.type === 'CLEAR_CACHE'){
+    event.waitUntil(
+      caches.keys()
+        .then(keys => Promise.all(keys.map(k => caches.delete(k))))
+        .then(() => caches.open(CACHE_NAME))
+        .then(cache => cache.addAll(CORE_ASSETS))
+        .then(() => event.ports[0] && event.ports[0].postMessage('UPDATED'))
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- polish aesthetic with new color theme, top bar spacing and button interactions
- use relative asset paths so the app and PWA work when not served from domain root
- cache updated paths in service worker
- set a fixed width for weekly and all-time XP cards so they align
- add an Update button to flush the service worker cache and pull fresh files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c593f4870883318ac6e7af2ff3f1ce