### PR TITLE
fix: wrap completed tasks table

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,3 @@
-
 :root{--bg:#e2e8f0;--bg2:#f8fafc;--card:#ffffff;--ink:#1e293b;--muted:#64748b;--border:#e2e8f0;--ring:#93c5fd;--accent:#6366f1}
 *{box-sizing:border-box}
 body{margin:0;min-height:100vh;background:linear-gradient(135deg,var(--bg2),var(--bg));color:var(--ink);font:15px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial}
@@ -22,6 +21,11 @@ label{display:block;font-size:12px;color:var(--muted);margin:10px 0 4px}
 input{width:100%;padding:10px;border:1px solid var(--border);border-radius:12px;outline:0} input:focus{box-shadow:0 0 0 3px var(--ring)}
 table{width:100%;border-collapse:collapse;font-size:13px}
 th,td{padding:10px;text-align:left;border-top:1px solid var(--border)}
+#historyTableWrap{overflow-x:auto}
+@media(max-width:600px){
+  #historyTableWrap table{table-layout:fixed}
+  #historyTableWrap th,#historyTableWrap td{word-break:break-word;white-space:normal}
+}
 .pill{padding:2px 8px;border-radius:999px;border:1px solid}
 .pill.red{background:#fee2e2;border-color:#fecaca}
 .pill.yellow{background:#fef9c3;border-color:#fde68a}


### PR DESCRIPTION
## Summary
- allow completed tasks table to scroll on small screens
- wrap table cells on narrow viewports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a56f634883318a8dc7b6b13ce18c