### PR TITLE
Await Service Worker before clearing cache

### DIFF
--- a/app.js
+++ b/app.js
@@ -294,12 +294,17 @@ document.addEventListener('DOMContentLoaded', ()=>{
     if(confirm('Reset all data? This cannot be undone.')){ state = { ...defaultState }; renderAll(); }
   });
   $('#updateBtn').addEventListener('click', async ()=>{
-    if('serviceWorker' in navigator && navigator.serviceWorker.controller){
-      const mc = new MessageChannel();
-      mc.port1.onmessage = () => window.location.reload();
-      navigator.serviceWorker.controller.postMessage({type:'CLEAR_CACHE'}, [mc.port2]);
+    if('serviceWorker' in navigator){
+      await navigator.serviceWorker.ready;
+      if(navigator.serviceWorker.controller){
+        const mc = new MessageChannel();
+        mc.port1.onmessage = () => window.location.reload();
+        navigator.serviceWorker.controller.postMessage({type:'CLEAR_CACHE'}, [mc.port2]);
+      } else {
+        alert('No Service Worker available to update.');
+      }
     } else {
-      window.location.reload();
+      alert('Service Worker not supported.');
     }
   });
   const powerLink = $('#powerLink');


### PR DESCRIPTION
## Summary
- wait for the Service Worker to be ready before sending the CLEAR_CACHE message
- inform user when Service Worker is not available or supported

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a70beb0c8331a73572f759a49e42