### PR TITLE
Simplify completed tasks view with details modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,7 +42,7 @@ function save(s){ localStorage.setItem(LS_KEY, JSON.stringify(s)); }
 let state = load();
 
 // -------------------- Tabs ---------------------------------------------------
-let sections, activeTab='planner';
+let sections, activeTab='planner', historyModal, historyDetails;
 function switchTab(name){
   activeTab = name;
   Object.entries(sections).forEach(([k,el])=> el.classList.toggle('hidden', k!==name));
@@ -185,18 +185,31 @@ function renderHistory(){
   if(!state.history.length){ empty.classList.remove('hidden'); wrap.classList.add('hidden'); return; }
   empty.classList.add('hidden'); wrap.classList.remove('hidden');
   tbody.innerHTML='';
-  state.history.forEach(h=>{
+  state.history.forEach((h,idx)=>{
     const tr = el('tr');
+    const link = el('a',{href:'#'},'View');
+    link.addEventListener('click', e=>{ e.preventDefault(); showHistoryDetails(idx); });
     tr.append(
-      el('td',{},new Date(h.completedAt).toLocaleString()),
-      el('td',{}, el('span',{class:`pill ${PRIORITIES[h.priority].pill}`}, PRIORITIES[h.priority].label)),
+      el('td',{}, new Date(h.completedAt).toLocaleString()),
       el('td',{}, h.title),
-      el('td',{}, h.people||'—'),
-      el('td',{}, h.deliverable||'—'),
-      el('td',{style:'text-align:right;font-weight:600'}, String(h.xpAwarded))
+      el('td',{}, link)
     );
     tbody.appendChild(tr);
   });
+}
+
+function showHistoryDetails(idx){
+  const h = state.history[idx];
+  if(!h) return;
+  historyDetails.innerHTML = `
+    <p><b>Task:</b> ${h.title}</p>
+    <p><b>Priority:</b> ${PRIORITIES[h.priority].label}</p>
+    <p><b>Involved:</b> ${h.people || '—'}</p>
+    <p><b>Deliverable:</b> ${h.deliverable || '—'}</p>
+    <p><b>XP:</b> ${h.xpAwarded}</p>
+    <p><b>Completed:</b> ${new Date(h.completedAt).toLocaleString()}</p>
+  `;
+  historyModal.classList.remove('hidden');
 }
 
 // ----- Robot
@@ -313,6 +326,11 @@ document.addEventListener('DOMContentLoaded', ()=>{
   powerLink.addEventListener('click', e=>{ e.preventDefault(); powerModal.classList.remove('hidden'); });
   powerClose.addEventListener('click', ()=> powerModal.classList.add('hidden'));
   powerModal.addEventListener('click', e=>{ if(e.target===powerModal) powerModal.classList.add('hidden'); });
+  historyModal = $('#historyModal');
+  historyDetails = $('#historyDetails');
+  const historyClose = $('#historyClose');
+  historyClose.addEventListener('click', ()=> historyModal.classList.add('hidden'));
+  historyModal.addEventListener('click', e=>{ if(e.target===historyModal) historyModal.classList.add('hidden'); });
   renderAll();
   switchTab('planner');
   pwaSetup();

--- a/index.html
+++ b/index.html
@@ -60,24 +60,34 @@
       </div>
     </section>
 
-    <section id="history" class="tab card hidden">
-      <h2 style="margin:0 0 8px">Completed Tasks</h2>
-      <div id="historyEmpty" class="muted">No completed tasks yet.</div>
-      <div id="historyTableWrap" class="hidden">
-        <table>
-          <thead>
-            <tr class="muted"><th>Completed</th><th>Priority</th><th>Task</th><th>Involved</th><th>Deliverable</th><th style="text-align:right">XP</th></tr>
-          </thead>
-          <tbody id="historyTbody"></tbody>
-        </table>
-      </div>
-    </section>
+      <section id="history" class="tab card hidden">
+        <h2 style="margin:0 0 8px">Completed Tasks</h2>
+        <div id="historyEmpty" class="muted">No completed tasks yet.</div>
+        <div id="historyTableWrap" class="hidden">
+          <table>
+            <thead>
+              <tr class="muted"><th>Completed</th><th>Task</th><th></th></tr>
+            </thead>
+            <tbody id="historyTbody"></tbody>
+          </table>
+        </div>
+      </section>
   <footer class="footer">
     <button id="updateBtn" class="btn">Update</button>
   </footer>
-</div>
+  </div>
 
-<div id="powerModal" class="modal hidden">
+  <div id="historyModal" class="modal hidden">
+    <div class="modal-content">
+      <h2>Task Details</h2>
+      <div id="historyDetails"></div>
+      <div style="text-align:right;margin-top:16px">
+        <button id="historyClose" class="btn">Close</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="powerModal" class="modal hidden">
   <div class="modal-content">
     <h2>The Power of 3</h2>
     <p>Most task lists fail because they try to do too much. You open the app, dump in everything you might want to accomplish, and suddenly your to-do list feels more like a guilt trip than a productivity tool.</p>


### PR DESCRIPTION
## Summary
- Reduce completed tasks table to date, description, and view link
- Add modal to display full task details on demand

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a85c653083318db6e3418449285a