### PR TITLE
Refine history table layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -191,8 +191,10 @@ function renderHistory(){
     link.addEventListener('click', e=>{ e.preventDefault(); showHistoryDetails(idx); });
     tr.append(
       el('td',{}, new Date(h.completedAt).toLocaleString()),
-      el('td',{}, h.title),
-      el('td',{}, link)
+      el('td',{}, [
+        el('div',{}, h.title),
+        el('div',{style:'margin-top:4px'}, link)
+      ])
     );
     tbody.appendChild(tr);
   });

--- a/index.html
+++ b/index.html
@@ -65,8 +65,12 @@
         <div id="historyEmpty" class="muted">No completed tasks yet.</div>
         <div id="historyTableWrap" class="hidden">
           <table>
+            <colgroup>
+              <col style="width:33%" />
+              <col style="width:67%" />
+            </colgroup>
             <thead>
-              <tr class="muted"><th>Completed</th><th>Task</th><th></th></tr>
+              <tr class="muted"><th>Completed</th><th>Task</th></tr>
             </thead>
             <tbody id="historyTbody"></tbody>
           </table>

--- a/styles.css
+++ b/styles.css
@@ -22,8 +22,8 @@ input{width:100%;padding:10px;border:1px solid var(--border);border-radius:12px;
 table{width:100%;border-collapse:collapse;font-size:13px}
 th,td{padding:10px;text-align:left;border-top:1px solid var(--border)}
 #historyTableWrap{overflow-x:auto}
+#historyTableWrap table{table-layout:fixed}
 @media(max-width:600px){
-  #historyTableWrap table{table-layout:fixed}
   #historyTableWrap th,#historyTableWrap td{word-break:break-word;white-space:normal}
 }
 .pill{padding:2px 8px;border-radius:999px;border:1px solid}


### PR DESCRIPTION
## Summary
- widen task column in history table and drop separate view column
- move task view link below description for cleaner layout
- enforce fixed table layout for consistent column widths

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b4f0b08083319976376775205fd4