### PR TITLE
Refine history table layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -191,8 +191,10 @@ function renderHistory(){
     link.addEventListener('click', e=>{ e.preventDefault(); showHistoryDetails(idx); });
     tr.append(
       el('td',{}, new Date(h.completedAt).toLocaleString()),
-      el('td',{}, h.title),
-      el('td',{}, link)
+      el('td',{}, [
+        el('div',{}, h.title),
+        el('div',{style:'margin-top:4px'}, link)
+      ])
     );
     tbody.appendChild(tr);
   });

--- a/index.html
+++ b/index.html
@@ -65,8 +65,12 @@
         <div id="historyEmpty" class="muted">No completed tasks yet.</div>
         <div id="historyTableWrap" class="hidden">
           <table>
+            <colgroup>
+              <col style="width:33%" />
+              <col style="width:67%" />
+            </colgroup>
             <thead>
-              <tr class="muted"><th>Completed</th><th>Task</th><th></th></tr>
+              <tr class="muted"><th>Completed</th><th>Task</th></tr>
             </thead>
             <tbody id="historyTbody"></tbody>
           </table>

--- a/styles.css
+++ b/styles.css
@@ -20,10 +20,10 @@ h1{font-size:32px;margin:0 0 8px}
 label{display:block;font-size:12px;color:var(--muted);margin:10px 0 4px}
 input{width:100%;padding:10px;border:1px solid var(--border);border-radius:12px;outline:0} input:focus{box-shadow:0 0 0 3px var(--ring)}
 table{width:100%;border-collapse:collapse;font-size:13px}
-th,td{padding:10px;text-align:left;border-top:1px solid var(--border)}
+th,td{padding:10px;text-align:left;vertical-align:top;border-top:1px solid var(--border)}
 #historyTableWrap{overflow-x:auto}
+#historyTableWrap table{table-layout:fixed}
 @media(max-width:600px){
-  #historyTableWrap table{table-layout:fixed}
   #historyTableWrap th,#historyTableWrap td{word-break:break-word;white-space:normal}
 }
 .pill{padding:2px 8px;border-radius:999px;border:1px solid}


### PR DESCRIPTION
## Summary
- widen task column in history table and drop separate view column
- move task view link below description for cleaner layout
- enforce fixed table layout for consistent column widths
- top-align completed task rows for improved readability

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b4f0b08083319976376775205fd4