### PR TITLE
feat: replace reset confirm with modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -305,9 +305,17 @@ function pwaSetup(){
 document.addEventListener('DOMContentLoaded', ()=>{
   sections = { planner:$('#planner'), robot:$('#robot'), history:$('#history') };
   document.querySelectorAll('nav [data-tab]').forEach(btn=>btn.addEventListener('click', ()=>switchTab(btn.dataset.tab)));
-  $('#resetBtn').addEventListener('click',()=>{
-    if(confirm('Reset all data? This cannot be undone.')){ state = { ...defaultState }; renderAll(); }
+  const resetModal = $('#resetModal');
+  const resetConfirm = $('#resetConfirm');
+  const resetCancel = $('#resetCancel');
+  $('#resetBtn').addEventListener('click',()=> resetModal.classList.remove('hidden'));
+  resetCancel.addEventListener('click', ()=> resetModal.classList.add('hidden'));
+  resetConfirm.addEventListener('click', ()=>{
+    state = { ...defaultState };
+    renderAll();
+    resetModal.classList.add('hidden');
   });
+  resetModal.addEventListener('click', e=>{ if(e.target===resetModal) resetModal.classList.add('hidden'); });
   $('#updateBtn').addEventListener('click', async ()=>{
     if('serviceWorker' in navigator){
       await navigator.serviceWorker.ready;

--- a/index.html
+++ b/index.html
@@ -81,6 +81,17 @@
   </footer>
   </div>
 
+  <div id="resetModal" class="modal hidden">
+    <div class="modal-content">
+      <h2>Reset All Data?</h2>
+      <p>This will remove all tasks and cannot be undone.</p>
+      <div style="text-align:right;margin-top:16px;display:flex;gap:8px;justify-content:flex-end">
+        <button id="resetCancel" class="btn">Cancel</button>
+        <button id="resetConfirm" class="btn warn">Reset</button>
+      </div>
+    </div>
+  </div>
+
   <div id="historyModal" class="modal hidden">
     <div class="modal-content">
       <h2>Task Details</h2>


### PR DESCRIPTION
## Summary
- replace browser confirm for resetting data with custom modal dialog
- add reset confirmation modal markup with cancel and reset options

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68c5bbad8eb88331a9b6aa8aaa2aaefa