### PR TITLE
Handle service worker update errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -321,7 +321,19 @@ document.addEventListener('DOMContentLoaded', ()=>{
       await navigator.serviceWorker.ready;
       if(navigator.serviceWorker.controller){
         const mc = new MessageChannel();
-        mc.port1.onmessage = () => window.location.reload();
+        const timeout = setTimeout(() => {
+          alert('No response from Service Worker. Reloading...');
+          window.location.reload();
+        }, 5000);
+        mc.port1.onmessage = (e) => {
+          clearTimeout(timeout);
+          const data = e.data;
+          if(data?.status === 'error'){
+            alert(`Update failed: ${data.message}`);
+          } else {
+            window.location.reload();
+          }
+        };
         navigator.serviceWorker.controller.postMessage({type:'CLEAR_CACHE'}, [mc.port2]);
       } else {
         alert('No Service Worker available to update.');

--- a/sw.js
+++ b/sw.js
@@ -37,6 +37,7 @@ self.addEventListener('message', (event) => {
         .then(() => caches.open(CACHE_NAME))
         .then(cache => cache.addAll(CORE_ASSETS))
         .then(() => event.ports[0] && event.ports[0].postMessage('UPDATED'))
+        .catch(err => event.ports[0]?.postMessage({status:'error', message: err.message}))
     );
   }
 });


### PR DESCRIPTION
## Summary
- catch cache clearing errors in service worker and report back
- handle service worker update errors in app.js and add timeout fallback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c5985dcc83318f64fbd06233d2d2