### PR TITLE
Allow unlimited prioritized tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
     </nav>
 
     <section id="planner" class="tab card">
+      <div id="taskCreator"></div>
       <div class="grid cols-3">
         <div class="slot" data-priority="red"></div>
         <div class="slot" data-priority="yellow"></div>

--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,8 @@ h1{font-size:32px;margin:0 0 8px}
 .grid{display:grid;gap:12px}
 @media(min-width:840px){.grid.cols-3{grid-template-columns:repeat(3,1fr)} .grid.cols-2{grid-template-columns:2fr 1fr}}
 label{display:block;font-size:12px;color:var(--muted);margin:10px 0 4px}
-input{width:100%;padding:10px;border:1px solid var(--border);border-radius:12px;outline:0} input:focus{box-shadow:0 0 0 3px var(--ring)}
+input,select{width:100%;padding:10px;border:1px solid var(--border);border-radius:12px;outline:0;background:#fff}
+input:focus,select:focus{box-shadow:0 0 0 3px var(--ring)}
 table{width:100%;border-collapse:collapse;font-size:13px}
 th,td{padding:10px;text-align:left;vertical-align:top;border-top:1px solid var(--border)}
 #historyTableWrap{overflow-x:auto}
@@ -34,6 +35,19 @@ th,td{padding:10px;text-align:left;vertical-align:top;border-top:1px solid var(-
 .hidden{display:none}
 .install{background:#eef2ff;border-color:#c7d2fe;color:#3730a3}
 .xp-card{padding:8px 12px;width:110px}
+.slot-header{margin-bottom:12px}
+.empty-state{padding:12px;border:1px dashed var(--border);border-radius:12px;background:#f8fafc;font-size:13px}
+.task-form{border:1px solid var(--border);border-radius:16px;padding:16px;background:#f8fafc;display:flex;flex-direction:column;gap:12px}
+.task-form-grid{display:grid;gap:12px}
+@media(min-width:720px){.task-form-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+.task-card{border:1px solid var(--border);border-radius:16px;padding:16px;background:#fff;margin-top:12px;box-shadow:0 1px 2px rgba(15,23,42,.06)}
+.task-card.red{border-color:#fecaca;background:#fff5f5}
+.task-card.yellow{border-color:#fde68a;background:#fffbeb}
+.task-card.green{border-color:#bbf7d0;background:#f0fdf4}
+.task-card-header{margin-bottom:8px}
+.task-details > div + div{margin-top:12px}
+.task-actions{margin-top:12px}
+#taskCreator{margin-bottom:16px}
 .footer{text-align:center;margin-top:24px}
 .modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;padding:16px}
 .modal-content{background:var(--card);max-width:600px;width:100%;max-height:90vh;overflow:auto;padding:24px;border-radius:16px}


### PR DESCRIPTION
## Summary
- store planner tasks in an array, migrate existing saves, and award a flat 5 XP per completion
- add a creation form with selectable priority plus multi-task column rendering and editing
- refresh planner styles to support unlimited task cards across the three priority columns

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d4a69872b8833197661cdeee3ed9e2